### PR TITLE
Add runtime i18n support with language switcher

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,7 +15,7 @@ import { ArticleComponent } from './article/article.component';
 import {MarkdownModule} from "ngx-markdown";
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {MatProgressSpinnerModule} from "@angular/material/progress-spinner";
-import {MatCard, MatCardModule} from "@angular/material/card";
+import { TranslatePipe } from './i18n/translate.pipe';
 
 
 @NgModule({
@@ -27,7 +27,8 @@ import {MatCard, MatCardModule} from "@angular/material/card";
     BbsComponent,
     NavComponent,
     FooterComponent,
-    ArticleComponent
+    ArticleComponent,
+    TranslatePipe
   ],
   imports: [
     BrowserModule,

--- a/src/app/article/article.component.html
+++ b/src/app/article/article.component.html
@@ -1,6 +1,6 @@
 <section class="page-hero" *ngIf="issue">
   <div class="container">
-    <span class="eyebrow">赤乌堂 · 最新消息</span>
+    <span class="eyebrow">{{ 'news.eyebrow' | t }}</span>
     <h1>{{ issue.title }}</h1>
     <div class="meta">
       <img class="avatar" src="{{ issue.user.avatar_url }}" alt="{{ issue.user.login }}">

--- a/src/app/bbs/bbs.component.html
+++ b/src/app/bbs/bbs.component.html
@@ -1,16 +1,16 @@
 <section class="page-hero">
   <div class="container">
-    <span class="eyebrow">赤乌堂 · 投稿</span>
-    <h1>投稿</h1>
-    <p>欢迎推理爱好者投稿，与读书会一起记录讨论与创作成果。</p>
+    <span class="eyebrow">{{ 'bbs.eyebrow' | t }}</span>
+    <h1>{{ 'bbs.title' | t }}</h1>
+    <p>{{ 'bbs.desc' | t }}</p>
   </div>
 </section>
 
 <section class="section">
   <div class="container">
     <div class="section-header">
-      <h2>栏目设置</h2>
-      <p>长期征稿栏目如下：</p>
+      <h2>{{ 'bbs.section.columns' | t }}</h2>
+      <p>{{ 'bbs.section.columns.desc' | t }}</p>
     </div>
     <div class="info-list">
       <div class="info-item">
@@ -36,20 +36,20 @@
 <section class="section muted">
   <div class="container">
     <div class="section-header">
-      <h2>投递方式</h2>
-      <p>长期征稿，欢迎随时投稿。</p>
+      <h2>{{ 'bbs.section.submit' | t }}</h2>
+      <p>{{ 'bbs.section.submit.desc' | t }}</p>
     </div>
     <div class="submission-grid">
       <div class="submission-card">
-        <h3>邮箱投递</h3>
-        <p>请发送附件至 <strong>qingwatang2022@qq.com</strong>，三周内将发送回执。</p>
-        <a class="btn primary" href="mailto:qingwatang2022@qq.com?subject=%E6%8A%95%E7%A8%BF&body=%E7%AC%94%E5%90%8D%EF%BC%9A%0AQQ%EF%BC%9A%0A%E8%81%94%E7%B3%BB%E6%96%B9%E5%BC%8F%EF%BC%9A">一键发送邮件</a>
+        <h3>{{ 'bbs.mail.title' | t }}</h3>
+        <p>{{ 'bbs.mail.desc' | t }}</p>
+        <a class="btn primary" href="mailto:qingwatang2022@qq.com?subject=%E6%8A%95%E7%A8%BF&body=%E7%AC%94%E5%90%8D%EF%BC%9A%0AQQ%EF%BC%9A%0A%E8%81%94%E7%B3%BB%E6%96%B9%E5%BC%8F%EF%BC%9A">{{ 'bbs.mail.button' | t }}</a>
       </div>
   
       <div class="submission-card">
         <h3>投稿须知</h3>
         <p>请注明笔名与联系方式（QQ 为主），所有稿件将在截止日后三周内统一回复。</p>
-        <p>《磷》将于截止后三个月内在官方网站公开，并提供 PDF 下载。</p>
+        <p>《磷》将于截止后三个月内在官方网站公开，并提供 PDF {{ 'book.download' | t }}。</p>
       </div>
     </div>
   </div>

--- a/src/app/book/book.component.html
+++ b/src/app/book/book.component.html
@@ -1,16 +1,16 @@
 <section class="page-hero">
   <div class="container">
-    <span class="eyebrow">赤乌堂 · 刊物一览</span>
-    <h1>刊物一览</h1>
-    <p>整理读书会刊物与专题资料，方便随时阅读与收藏。</p>
+    <span class="eyebrow">{{ 'book.eyebrow' | t }}</span>
+    <h1>{{ 'book.title' | t }}</h1>
+    <p>{{ 'book.desc' | t }}</p>
   </div>
 </section>
 
 <section class="section">
   <div class="container">
     <div class="section-header">
-      <h2>《磷》系列</h2>
-      <p>聚焦推理主题的刊物合集，按卷持续更新。</p>
+      <h2>{{ 'book.series.title' | t }}</h2>
+      <p>{{ 'book.series.desc' | t }}</p>
     </div>
 
     <div class="book-grid">
@@ -20,8 +20,8 @@
           <h3>《磷》第四卷</h3>
           <p>最新一期内容，聚合推理阅读与创作心得。</p>
           <div class="book-actions">
-            <a class="btn primary" href="https://phospho4.chiwutang.uk/">在线阅读</a>
-            <a class="btn ghost" href="https://download.chiwutang.uk/Phospho4.pdf">下载</a>
+            <a class="btn primary" href="https://phospho4.chiwutang.uk/">{{ 'book.read' | t }}</a>
+            <a class="btn ghost" href="https://download.chiwutang.uk/Phospho4.pdf">{{ 'book.download' | t }}</a>
           </div>
         </div>
       </article>
@@ -32,8 +32,8 @@
           <h3>《磷》第三卷</h3>
           <p>收录讨论与读后记录，适合整体回顾。</p>
           <div class="book-actions">
-            <a class="btn primary" href="https://phospho3.chiwutang.uk/">在线阅读</a>
-            <a class="btn ghost" href="https://download.chiwutang.uk/Phospho3.pdf">下载</a>
+            <a class="btn primary" href="https://phospho3.chiwutang.uk/">{{ 'book.read' | t }}</a>
+            <a class="btn ghost" href="https://download.chiwutang.uk/Phospho3.pdf">{{ 'book.download' | t }}</a>
           </div>
         </div>
       </article>
@@ -44,8 +44,8 @@
           <h3>《磷》第二卷</h3>
           <p>整理早期共读主题与推荐书目。</p>
           <div class="book-actions">
-            <a class="btn primary" href="https://phospho2.chiwutang.uk/">在线阅读</a>
-            <a class="btn ghost" href="https://download.chiwutang.uk/Phospho2.pdf">下载</a>
+            <a class="btn primary" href="https://phospho2.chiwutang.uk/">{{ 'book.read' | t }}</a>
+            <a class="btn ghost" href="https://download.chiwutang.uk/Phospho2.pdf">{{ 'book.download' | t }}</a>
           </div>
         </div>
       </article>
@@ -56,8 +56,8 @@
           <h3>《磷》第一卷</h3>
           <p>读书会初刊，记录第一批共读成果。</p>
           <div class="book-actions">
-            <a class="btn primary" href="https://phospho1.chiwutang.uk/">在线阅读</a>
-            <a class="btn ghost" href="https://phospho1.chiwutang.uk/Phospho1.pdf">下载</a>
+            <a class="btn primary" href="https://phospho1.chiwutang.uk/">{{ 'book.read' | t }}</a>
+            <a class="btn ghost" href="https://phospho1.chiwutang.uk/Phospho1.pdf">{{ 'book.download' | t }}</a>
           </div>
         </div>
       </article>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -2,12 +2,12 @@
 	<footer class="bg-white border-top p-3 text-muted small">
 	<div class="row align-items-center justify-content-between">
 		<div>
-            <span class="navbar-brand mr-2"><strong>赤乌堂</strong></span> Copyright &copy; 2021-2026
+            <span class="navbar-brand mr-2"><strong>{{ 'brand.name' | t }}</strong></span> Copyright &copy; 2021-2026
 			<script>document.write(new Date().getFullYear())</script>
-			 . All rights reserved.
+			 . {{ 'footer.copyright' | t }}
 		</div>
 		<div>
-			磷磷萤火，愿逐月华
+			{{ 'footer.slogan' | t }}
 		</div>
 	</div>
 	</footer>

--- a/src/app/i18n/i18n.service.ts
+++ b/src/app/i18n/i18n.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { LanguageCode, translations } from './translations';
+
+const STORAGE_KEY = 'chiwutang-lang';
+
+@Injectable({ providedIn: 'root' })
+export class I18nService {
+  private readonly defaultLanguage: LanguageCode = 'zh-CN';
+  private readonly languageSubject = new BehaviorSubject<LanguageCode>(this.defaultLanguage);
+  readonly language$ = this.languageSubject.asObservable();
+
+  constructor() {
+    const detected = this.getInitialLanguage();
+    this.setLanguage(detected);
+  }
+
+  get language(): LanguageCode {
+    return this.languageSubject.value;
+  }
+
+  setLanguage(language: LanguageCode): void {
+    this.languageSubject.next(language);
+    localStorage.setItem(STORAGE_KEY, language);
+    document.documentElement.lang = language;
+  }
+
+  translate(key: string): string {
+    const current = translations[this.language][key];
+    if (current) {
+      return current;
+    }
+
+    return translations[this.defaultLanguage][key] ?? key;
+  }
+
+  private getInitialLanguage(): LanguageCode {
+    const fromStorage = localStorage.getItem(STORAGE_KEY);
+    if (fromStorage === 'zh-CN' || fromStorage === 'en-US') {
+      return fromStorage;
+    }
+
+    const browserLanguage = navigator.language.toLowerCase();
+    return browserLanguage.startsWith('zh') ? 'zh-CN' : 'en-US';
+  }
+}

--- a/src/app/i18n/translate.pipe.ts
+++ b/src/app/i18n/translate.pipe.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectorRef, OnDestroy, Pipe, PipeTransform } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { I18nService } from './i18n.service';
+
+@Pipe({
+  name: 't',
+  pure: false
+})
+export class TranslatePipe implements PipeTransform, OnDestroy {
+  private readonly subscription: Subscription;
+
+  constructor(private readonly i18n: I18nService, private readonly cdr: ChangeDetectorRef) {
+    this.subscription = this.i18n.language$.subscribe(() => {
+      this.cdr.markForCheck();
+    });
+  }
+
+  transform(key: string): string {
+    return this.i18n.translate(key);
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+}

--- a/src/app/i18n/translations.ts
+++ b/src/app/i18n/translations.ts
@@ -1,0 +1,112 @@
+export type LanguageCode = 'zh-CN' | 'en-US';
+
+export const translations: Record<LanguageCode, Record<string, string>> = {
+  'zh-CN': {
+    'brand.name': '赤乌堂',
+    'nav.about': '关于我们',
+    'nav.news': '最新消息',
+    'nav.books': '刊物一览',
+    'nav.submit': '投稿中心',
+
+    'index.eyebrow': '赤乌堂 · 推理评论研究会',
+    'index.title': '磷磷萤火，愿逐月华',
+    'index.desc': '赤乌堂成立于2021年，名不见经传的推理爱好者小团体。大家因共同话题而走到一起，决定短暂地，一起做一件小事。不论赤乌，抑或磷火，都包含了同一种属性的意向：光芒。因此，即使是小事，我们也正在努力地将自己的成果向更远方发散出去。只因为我们也想要去做那一点微芒——磷磷萤火，愿逐月华。',
+    'index.cta.news': '最新消息',
+    'index.cta.books': '刊物一览',
+    'index.latest.call': '最新征稿',
+    'index.latest.volume': '《磷》第五卷',
+    'index.latest.deadline': '截止至2026年2月1日',
+    'index.member.title': '成员与分工',
+    'index.member.alien': '策划 · 美工 · 🛸',
+    'index.member.muhai': '审稿 · 校对',
+    'index.member.wanger': '审稿 · 校对',
+    'index.member.uu': '校对',
+    'index.member.hyl': '发布推广 · 📡',
+    'index.next.title': '一起翻开下一页',
+    'index.next.desc': '欢迎投稿，让你的灵感被看见。',
+    'index.next.button': '前往投稿',
+
+    'footer.copyright': '版权所有。',
+    'footer.slogan': '磷磷萤火，愿逐月华',
+
+    'book.eyebrow': '赤乌堂 · 刊物一览',
+    'book.title': '刊物一览',
+    'book.desc': '整理读书会刊物与专题资料，方便随时阅读与收藏。',
+    'book.series.title': '《磷》系列',
+    'book.series.desc': '聚焦推理主题的刊物合集，按卷持续更新。',
+    'book.read': '在线阅读',
+    'book.download': '下载',
+
+    'news.eyebrow': '赤乌堂 · 最新消息',
+    'news.title': '最新消息',
+    'news.desc': '记录读书会的最新文章、讨论与更新，方便快速追踪与回顾。',
+
+    'bbs.eyebrow': '赤乌堂 · 投稿',
+    'bbs.title': '投稿',
+    'bbs.desc': '欢迎推理爱好者投稿，与读书会一起记录讨论与创作成果。',
+    'bbs.section.columns': '栏目设置',
+    'bbs.section.columns.desc': '长期征稿栏目如下：',
+    'bbs.section.submit': '投递方式',
+    'bbs.section.submit.desc': '长期征稿，欢迎随时投稿。',
+    'bbs.mail.title': '邮箱投递',
+    'bbs.mail.desc': '请发送附件至 qingwatang2022@qq.com，三周内将发送回执。',
+    'bbs.mail.button': '一键发送邮件',
+
+    'lang.zh': '中',
+    'lang.en': 'EN'
+  },
+  'en-US': {
+    'brand.name': 'Chiwutang',
+    'nav.about': 'About',
+    'nav.news': 'News',
+    'nav.books': 'Books',
+    'nav.submit': 'Submit',
+
+    'index.eyebrow': 'Chiwutang · Detective Fiction Review Group',
+    'index.title': 'Like Fireflies, We Chase the Moonlight',
+    'index.desc': 'Founded in 2021, Chiwutang is a small but passionate circle of mystery readers. We came together around shared interests and chose to do something meaningful together, even if only in a modest way. Whether "Red Crow" or "Phosphorescence," both point to one thing: light. So even for small work, we keep trying to let it travel farther.',
+    'index.cta.news': 'Latest News',
+    'index.cta.books': 'Publications',
+    'index.latest.call': 'Open Call',
+    'index.latest.volume': 'Phospho Vol. 5',
+    'index.latest.deadline': 'Deadline: Feb 1, 2026',
+    'index.member.title': 'Team & Roles',
+    'index.member.alien': 'Planning · Design · 🛸',
+    'index.member.muhai': 'Review · Proofreading',
+    'index.member.wanger': 'Review · Proofreading',
+    'index.member.uu': 'Proofreading',
+    'index.member.hyl': 'Promotion · 📡',
+    'index.next.title': 'Turn to the Next Page Together',
+    'index.next.desc': 'Send us your work and let your ideas be seen.',
+    'index.next.button': 'Submit Now',
+
+    'footer.copyright': 'All rights reserved.',
+    'footer.slogan': 'Like Fireflies, We Chase the Moonlight',
+
+    'book.eyebrow': 'Chiwutang · Publications',
+    'book.title': 'Publications',
+    'book.desc': 'Collected journals and special issues for reading and archiving.',
+    'book.series.title': 'Phospho Series',
+    'book.series.desc': 'A growing collection focused on mystery criticism and reading notes.',
+    'book.read': 'Read Online',
+    'book.download': 'Download',
+
+    'news.eyebrow': 'Chiwutang · News',
+    'news.title': 'Latest News',
+    'news.desc': 'Updates, articles, and discussions from our reading group.',
+
+    'bbs.eyebrow': 'Chiwutang · Submission',
+    'bbs.title': 'Submission',
+    'bbs.desc': 'Mystery lovers are welcome to contribute and share their writing.',
+    'bbs.section.columns': 'Columns',
+    'bbs.section.columns.desc': 'We accept submissions in the following long-term columns:',
+    'bbs.section.submit': 'How to Submit',
+    'bbs.section.submit.desc': 'Open year-round. Send us your work anytime.',
+    'bbs.mail.title': 'Email',
+    'bbs.mail.desc': 'Send your attachment to qingwatang2022@qq.com. A receipt will be sent within 3 weeks.',
+    'bbs.mail.button': 'Send Email',
+
+    'lang.zh': '中文',
+    'lang.en': 'EN'
+  }
+};

--- a/src/app/index/index.component.html
+++ b/src/app/index/index.component.html
@@ -1,25 +1,19 @@
 <section class="hero">
   <div class="container hero-content">
     <div class="hero-text">
-      <span class="eyebrow">赤乌堂 · 推理评论研究会</span>
-      <h1>磷磷萤火，愿逐月华</h1>
-      <p>
-        赤乌堂成立于2021年，名不见经传的推理爱好者小团体。
-        大家因共同话题而走到一起，决定短暂地，一起做一件小事。
-        不论赤乌，抑或磷火，都包含了同一种属性的意向：光芒。
-        因此，即使是小事，我们也正在努力地将自己的成果向更远方发散出去。
-        只因为我们也想要去做那一点微芒——磷磷萤火，愿逐月华。
-      </p>
+      <span class="eyebrow">{{ 'index.eyebrow' | t }}</span>
+      <h1>{{ 'index.title' | t }}</h1>
+      <p>{{ 'index.desc' | t }}</p>
       <div class="hero-actions">
-        <a class="btn primary" routerLink="/news">最新消息</a>
-        <a class="btn ghost" routerLink="/books">刊物一览</a>
+        <a class="btn primary" routerLink="/news">{{ 'index.cta.news' | t }}</a>
+        <a class="btn ghost" routerLink="/books">{{ 'index.cta.books' | t }}</a>
       </div>
     </div>
     <div class="hero-visual" aria-hidden="true">
       <div class="hero-card">
-        <p>最新征稿</p>
-        <h3>《磷》第五卷</h3>
-        <span>截止至2026年2月1日</span>
+        <p>{{ 'index.latest.call' | t }}</p>
+        <h3>{{ 'index.latest.volume' | t }}</h3>
+        <span>{{ 'index.latest.deadline' | t }}</span>
       </div>
     </div>
   </div>
@@ -29,7 +23,7 @@
 <section class="section muted">
   <div class="container">
     <div class="section-header center">
-      <h2>成员与分工</h2>
+      <h2>{{ 'index.member.title' | t }}</h2>
 
     </div>
     <div class="member-grid">
@@ -37,35 +31,35 @@
         <img src="./assets/img/avatar/alien.png" alt="阿唯">
         <div>
           <h5>阿唯 👽</h5>
-          <span>策划 · 美工 · 🛸</span>
+          <span>{{ 'index.member.alien' | t }}</span>
         </div>
       </div>
       <div class="member-card">
         <img src="./assets/img/avatar/muhai.jpg" alt="木海">
         <div>
           <h5>木海</h5>
-          <span>审稿 · 校对</span>
+          <span>{{ 'index.member.muhai' | t }}</span>
         </div>
       </div>
       <div class="member-card">
         <img src="./assets/img/avatar/wanger.jpg" alt="王二">
         <div>
           <h5>王二</h5>
-          <span>审稿 · 校对</span>
+          <span>{{ 'index.member.wanger' | t }}</span>
         </div>
       </div>
       <div class="member-card">
         <img src="./assets/img/avatar/uu.jpg" alt="U.U">
         <div>
           <h5>U.U</h5>
-          <span>校对</span>
+          <span>{{ 'index.member.uu' | t }}</span>
         </div>
       </div>
       <div class="member-card">
         <img src="./assets/img/avatar/alien2.png" alt="韩雨洛">
         <div>
           <h5>韩雨洛 👽</h5>
-          <span>发布推广 · 📡</span>
+          <span>{{ 'index.member.hyl' | t }}</span>
         </div>
       </div>
     </div>
@@ -76,10 +70,10 @@
   <div class="container">
     <div class="cta">
       <div>
-        <h2>一起翻开下一页</h2>
-        <p>欢迎投稿，让你的灵感被看见。</p>
+        <h2>{{ 'index.next.title' | t }}</h2>
+        <p>{{ 'index.next.desc' | t }}</p>
       </div>
-      <a class="btn primary" routerLink="/bbs">前往投稿</a>
+      <a class="btn primary" routerLink="/bbs">{{ 'index.next.button' | t }}</a>
     </div>
   </div>
 </section>

--- a/src/app/index/index.component.ts
+++ b/src/app/index/index.component.ts
@@ -1,15 +1,28 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { I18nService } from '../i18n/i18n.service';
+
 @Component({
   selector: 'app-index',
   templateUrl: './index.component.html',
   styleUrls: ['./index.component.css']
 })
-export class IndexComponent implements OnInit {
+export class IndexComponent implements OnInit, OnDestroy {
+  private readonly destroy$ = new Subject<void>();
 
-  constructor(private titleService: Title) { this.titleService.setTitle("赤乌堂"); }
-
-  ngOnInit(): void {
+  constructor(private readonly titleService: Title, private readonly i18n: I18nService) {
   }
 
+  ngOnInit(): void {
+    this.i18n.language$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.titleService.setTitle(this.i18n.translate('brand.name')));
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 }

--- a/src/app/nav/nav.component.css
+++ b/src/app/nav/nav.component.css
@@ -24,3 +24,23 @@
 .nav-link:hover {
   color: #3b2f23;
 }
+
+.lang-switcher {
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.lang-btn {
+  border: 1px solid #d3c3b1;
+  background: #fff;
+  color: #5c4a3b;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  line-height: 1.3;
+}
+
+.lang-btn.active {
+  background: #5c4a3b;
+  color: #fff;
+}

--- a/src/app/nav/nav.component.html
+++ b/src/app/nav/nav.component.html
@@ -1,6 +1,6 @@
 <nav class="topnav navbar navbar-expand-lg navbar-light fixed-top">
 <div class="container">
-	<a class="navbar-brand" routerLink="/"><strong>赤乌堂</strong></a>
+	<a class="navbar-brand" routerLink="/"><strong>{{ 'brand.name' | t }}</strong></a>
 	<button
 		class="navbar-toggler"
 		type="button"
@@ -14,19 +14,23 @@
 	<div class="navbar-collapse collapse" id="navbarColor02" [ngClass]="{ show: isMobileMenuOpen }">
 		<ul class="navbar-nav mr-auto d-flex align-items-center">
 			<li class="nav-item">
-			<a class="nav-link" routerLink="" (click)="closeMobileMenu()">关于我们</a>
+			<a class="nav-link" routerLink="" (click)="closeMobileMenu()">{{ 'nav.about' | t }}</a>
 			</li>
 			<li class="nav-item">
-			<a class="nav-link" routerLink="news" (click)="closeMobileMenu()">最新消息</a>
+			<a class="nav-link" routerLink="news" (click)="closeMobileMenu()">{{ 'nav.news' | t }}</a>
 			</li>
 			<li class="nav-item">
-			<a class="nav-link" routerLink="book" (click)="closeMobileMenu()">刊物一览</a>
+			<a class="nav-link" routerLink="book" (click)="closeMobileMenu()">{{ 'nav.books' | t }}</a>
 			</li>
 			<li class="nav-item">
-			<a class="nav-link" routerLink="bbs" (click)="closeMobileMenu()">投稿中心</a>
+			<a class="nav-link" routerLink="bbs" (click)="closeMobileMenu()">{{ 'nav.submit' | t }}</a>
 			</li>
 
 		</ul>
+    <div class="lang-switcher">
+      <button class="lang-btn" [class.active]="i18n.language === 'zh-CN'" (click)="switchLanguage('zh-CN')">{{ 'lang.zh' | t }}</button>
+      <button class="lang-btn" [class.active]="i18n.language === 'en-US'" (click)="switchLanguage('en-US')">{{ 'lang.en' | t }}</button>
+    </div>
 	</div>
 </div>
 </nav>

--- a/src/app/nav/nav.component.ts
+++ b/src/app/nav/nav.component.ts
@@ -2,6 +2,8 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
+import { I18nService } from '../i18n/i18n.service';
+import { LanguageCode } from '../i18n/translations';
 
 @Component({
   selector: 'app-nav',
@@ -12,7 +14,7 @@ export class NavComponent implements OnInit, OnDestroy {
   isMobileMenuOpen = false;
   private readonly destroy$ = new Subject<void>();
 
-  constructor(private readonly router: Router) { }
+  constructor(private readonly router: Router, public readonly i18n: I18nService) { }
 
   ngOnInit(): void {
     this.router.events
@@ -34,5 +36,9 @@ export class NavComponent implements OnInit, OnDestroy {
 
   toggleMobileMenu(): void {
     this.isMobileMenuOpen = !this.isMobileMenuOpen;
+  }
+
+  switchLanguage(language: LanguageCode): void {
+    this.i18n.setLanguage(language);
   }
 }

--- a/src/app/news/news.component.html
+++ b/src/app/news/news.component.html
@@ -1,8 +1,8 @@
 <section class="page-hero">
   <div class="container">
-    <span class="eyebrow">赤乌堂 · 最新消息</span>
-    <h1>最新消息</h1>
-    <p>记录读书会的最新文章、讨论与更新，方便快速追踪与回顾。</p>
+    <span class="eyebrow">{{ 'news.eyebrow' | t }}</span>
+    <h1>{{ 'news.title' | t }}</h1>
+    <p>{{ 'news.desc' | t }}</p>
   </div>
 </section>
 


### PR DESCRIPTION
### Motivation
- Provide multilingual support (Chinese / English) so UI text can be switched at runtime without adding heavy third-party dependencies. 
- Allow the site to remember user preference and reflect language in `<html lang>` and page title. 

### Description
- Added a small runtime i18n system: `src/app/i18n/translations.ts` contains `zh-CN` and `en-US` dictionaries and `LanguageCode` type. 
- Implemented `I18nService` (`src/app/i18n/i18n.service.ts`) to detect browser language, persist selection in `localStorage`, expose `language$`, update `<html lang>`, and provide `translate(key)` lookup. 
- Added a non-pure `TranslatePipe` (`src/app/i18n/translate.pipe.ts`) named `t` and registered it in `AppModule` so templates can use `{{ 'key' | t }}`. 
- Updated templates and components (nav, index, book, news, bbs, article, footer) to use translation keys and added a language switcher UI in the top navigation that calls `I18nService.setLanguage`. 
- Made the index page title reactive to language changes by subscribing to `I18nService.language$` in `IndexComponent`. 

### Testing
- Ran `npm run build`; bundling proceeded but the build failed at the index HTML font inlining step because Google Fonts returned HTTP 403 in this environment, which is an external-environment limitation rather than an application logic compile error. 
- No unit tests were executed as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd249c50c83329fa5b765de5a8b03)